### PR TITLE
Bugfix: Crash on AppInit | API <= 22  

### DIFF
--- a/app/src/main/java/eu/berdosi/app/heartbeat/MainActivity.java
+++ b/app/src/main/java/eu/berdosi/app/heartbeat/MainActivity.java
@@ -130,7 +130,6 @@ public class MainActivity extends Activity implements ActivityCompat.OnRequestPe
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == REQUEST_CODE_CAMERA) {
             if (!(grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
                 Snackbar.make(


### PR DESCRIPTION
* Removes stub super() callback on permissions check
* Fixes #24 