### PR TITLE
Bugfix: Crash on Measurement Completed & Export Details | API <= 23

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -18,8 +18,8 @@
     <string name="new_measurement">নতুন পরিমাপ</string>
     <string name="export_result">ফলাফল রপ্তানি</string>
     <string name="export_details">বিস্তারিত তথ্য রপ্তানি</string>
-    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssXXX</string>
-    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX</string>
+    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssZZZZZ</string>
+    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ</string>
     <string name="camera_not_found">ক্যামেরা নেই।</string>
     <plurals name="measurement_output_template">
         <item quantity="zero">স্পন্দন: %2.1f (%2.1f সেকেন্ডে %d চক্র)</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -21,8 +21,8 @@
     <string name="new_measurement">Nueva medición</string>
     <string name="export_result">Exportar resultado</string>
     <string name="export_details">Exportar detalles</string>
-    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssXXX</string>
-    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX</string>
+    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssZZZZZ</string>
+    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ</string>
     <string name="camera_not_found">Cámara no disponible.</string>
     <plurals name="measurement_output_template">
         <item quantity="zero">Pulso: %2.1f (%d ciclos en %2.1f segundos)</item>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -19,8 +19,8 @@
     <string name="raw_values">Értékek (Időpont, Érték)</string>
     <string name="cameraPermissionRequired">Az alkalmazásnak a működéséhez hozzá kell férnie a kamerához.</string>
     <string name="noFlashWarning">Vaku nélkül a mérés kevésbé megbízható.</string>
-    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX</string>
-    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssXXX</string>
+    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ</string>
+    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssZZZZZ</string>
     <string name="separator">,</string>
     <string name="row_separator">\n</string>
     <string name="camera_not_found">A kamera nem elérhető.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,8 +21,8 @@
     <string name="new_measurement">Nieuwe meting </string>
     <string name="export_result">Resultaat exporteren</string>
     <string name="export_details">Details exporteren </string>
-    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssXXX</string>
-    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX</string>
+    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssZZZZZ</string>
+    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ</string>
     <plurals name="measurement_output_template">
         <item quantity="zero">Pulse: %2.1f (%d cycle in %2.1f seconds)</item>
         <item quantity="one">Pulse: %2.1f (%d cycle in %2.1f seconds)</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,8 +20,8 @@
     <string name="new_measurement">新的测量</string>
     <string name="export_result">导出结果</string>
     <string name="export_details">导出细节</string>
-    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssXXX</string>
-    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX</string>
+    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssZZZZZ</string>
+    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ</string>
     <plurals name="measurement_output_template">
         <item quantity="zero">Pulse: %2.1f (%d cycle in %2.1f seconds)</item>
         <item quantity="one">Pulse: %2.1f (%d cycle in %2.1f seconds)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,8 +21,8 @@
     <string name="new_measurement">New Measurement</string>
     <string name="export_result">Export Result</string>
     <string name="export_details">Export Details</string>
-    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssXXX</string>
-    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX</string>
+    <string name="dateFormat">yyyy-MM-dd\'T\'HH:mm:ssZZZZZ</string>
+    <string name="dateFormatGranular">yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ</string>
     <string name="camera_not_found">Camera not available.</string>
     <plurals name="measurement_output_template">
         <item quantity="zero">Pulse: %2.1f (%d cycle in %2.1f seconds)</item>


### PR DESCRIPTION
* Changes `dateFormat` and `dateFormatGranual` from XXX format to ZZZZZ
* Fixes #25
* Also fixes additional crash found when sharing via "Export Details"
* Tested on API 21, 22, 23, 24, 30, confirmed output format is same as previous pattern.
* Note: to test on API 21/22 requires #26 changes as well